### PR TITLE
fix warning of type mismatch in printf format

### DIFF
--- a/src/transpose.cpp
+++ b/src/transpose.cpp
@@ -2078,7 +2078,7 @@ std::shared_ptr<Plan> Transpose<floatType>::selectPlan( const std::vector<std::s
          }
       }
       if( this->infoLevel_ > 0 )
-         printf("We evaluated %d/%d candidates and selected candidate %d.\n", plansEvaluated, plans.size(), bestPlan_id); 
+         printf("We evaluated %d/%zu candidates and selected candidate %d.\n", plansEvaluated, plans.size(), bestPlan_id); 
    }
    return plans[bestPlan_id];
 }


### PR DESCRIPTION
Currently, the printf formatter `%d` is used for the unsigned `plans.size()`. This results in "warning: format specifies type 'int' but the argument has type 'size_type' (aka 'unsigned long') [-Wformat]".